### PR TITLE
Add host and port options to the testing server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python2.7
 
+import argparse
+
 import get5
 
-
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Testing web server for get5.')
+    parser.add_argument('--host', '-h', default='127.0.0.1',
+                        help='ip for the server to listen on')
+    parser.add_argument('--port', '-p', type=int, default=5000,
+                        help='port for the server to listen on')
+    args = parser.parse_args()
+    
     get5.db.create_all()
     get5.register_blueprints()
-    get5.app.run()
+    sys.stderr.write('Starting get5 testing server. This is for testing only, do not run in production.')
+    get5.app.run(host=args.host, port=args.port)


### PR DESCRIPTION
This should testing of the server on an external facing IP and port, which can be useful to know the application is working without forwarding ports.