### PR TITLE
Fix logger issue in match.py

### DIFF
--- a/get5/match.py
+++ b/get5/match.py
@@ -184,8 +184,8 @@ def match_create():
                 server.in_use = True
 
                 db.session.commit()
-                app.logger.info('User {} created match {}, assigned to server {}',
-                                g.user.id, match.id, server.id)
+                app.logger.info('User {} created match {}, assigned to server {}'
+                                .format(g.user.id, match.id, server.id))
 
                 if mock or match.send_to_server():
                     return redirect('/mymatches')


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file match.py, line 188