### PR TITLE
Fix logger issue in api.py

### DIFF
--- a/get5/api.py
+++ b/get5/api.py
@@ -70,7 +70,7 @@ def match_finish(matchid):
         server.in_use = False
 
     db.session.commit()
-    app.logger.info('Finished match {}, winner={}', match, winner)
+    app.logger.info('Finished match {}, winner={}'.format(match, winner))
 
     return 'Success'
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file api.py, line 73