### PR TITLE
Fixing Stacked Navbar Menu to Normal Inline Block

### DIFF
--- a/get5/templates/layout.html
+++ b/get5/templates/layout.html
@@ -32,10 +32,9 @@
       			</button>
             <a class="navbar-brand" href="/">Get5 Web Panel</a>
           </div>
+	<div class="collapse navbar-collapse" id="myNavbar">
           <ul class="nav navbar-nav">
-             <div class="collapse navbar-collapse" id="myNavbar">
             <li><a id="matches" href="/matches">All Matches</a></li>
-          
             {% if user %}
             <li><a id="mymatches" href="/mymatches">My Matches</a></li>
             <li><a id="match_create" href="/match/create">Create a Match</a></li>
@@ -47,7 +46,6 @@
             {% else %}
             <li><a href="/login">  <img src="/static/img/login_small.png" height="18"/></a></li>
             {% endif %}
-
           </ul>
         </div>
       </nav>


### PR DESCRIPTION
Small Class addition for Mobile was not done properly. Fixed now , Main menu got stacked on each other due to misplacement of div class .Now fixed it and should be working fine. 