### PR TITLE
fix(login): Fix an issue with setting admin permissions after an initial login

### DIFF
--- a/get5/models.py
+++ b/get5/models.py
@@ -28,8 +28,9 @@ class User(db.Model):
             rv.steam_id = steam_id
             db.session.add(rv)
             app.logger.info('Creating user for {}'.format(steam_id))
-            rv.admin = ('ADMIN_IDS' in app.config) and (
-                steam_id in app.config['ADMIN_IDS'])
+
+        rv.admin = ('ADMIN_IDS' in app.config) and (
+            steam_id in app.config['ADMIN_IDS'])
         return rv
 
     def get_url(self):


### PR DESCRIPTION
Fixes an issue whereby if a user is added to admin after their user row is created in the database, they would not be able to access required admin roles.