### PR TITLE
Fix charset

### DIFF
--- a/get5/__init__.py
+++ b/get5/__init__.py
@@ -43,6 +43,9 @@ sys.setdefaultencoding('utf-8')
 app = Flask(__name__, instance_relative_config=True)
 app.config.from_pyfile('prod_config.py')
 
+# Using match config of utf-8.
+app.config['JSON_AS_ASCII'] = False
+
 # Setup caching
 cache = flask.ext.cache.Cache(app, config={
     'CACHE_TYPE': 'filesystem',


### PR DESCRIPTION
Hi.
I'm japanese csgo player.

Fix charset in match config file.

I noticed in gaming team name is not ascii and confirmed match config is not utf-8 encoding.

This request is that.
You maybe have better way.