### PR TITLE
Make get5_loadmatch_url domain/ip configurable

### DIFF
--- a/get5/models.py
+++ b/get5/models.py
@@ -338,7 +338,7 @@ class Match(db.Model):
         get5UrlOverride = app.config['GET5_URL_OVERRIDE'];
 
         if get5UrlOverride:
-            url = get5UrlOverride + '/match/' + self.id + '/config';
+            url = get5UrlOverride + '/match/' + str(self.id) + '/config';
 
         # If no URL Override is set in the config, use the serverName the server was called with
         if not url:

--- a/get5/models.py
+++ b/get5/models.py
@@ -335,7 +335,14 @@ class Match(db.Model):
         if not server:
             return False
 
-        url = url_for('match.match_config', matchid=self.id,
+        get5UrlOverride = app.config['GET5_URL_OVERRIDE'];
+
+        if get5UrlOverride:
+            url = get5UrlOverride + '/match/' + self.id + '/config';
+
+        # If no URL Override is set in the config, use the serverName the server was called with
+        if not url:
+            url = url_for('match.match_config', matchid=self.id,
                       _external=True, _scheme='http')
         # Remove http protocal since the get5 plugin can't parse args with the
         # : in them.

--- a/instance/prod_config.py.default
+++ b/instance/prod_config.py.default
@@ -61,3 +61,8 @@ SPECTATOR_IDS = []
 # This specifies how much spectators are needed to ready up to get the match started/live
 # this is an optional configuration
 # MIN_SPECTATORS_TO_READY = 0
+
+# This overrides the default way to build the config URL that get appended to the get5_loadmatch_url rcon command.
+# Uncomment and use this if you need to set another ip for your get5 instance than the public ip you're using get5 with
+# in your browser.
+# GET5_URL_OVERRIDE = '127.0.0.1'


### PR DESCRIPTION
Implements https://github.com/splewis/get5-web/issues/179
Please review the code as I don't use python that often and couldn't check whether the code works as intended yet.