### PR TITLE
SetupTools issues with enum Repo

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,6 +63,7 @@ cd get5-web
 ```sh
 virtualenv venv
 source venv/bin/activate
+pip install --upgrade 'setuptools==44.1.0'
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
After EOL of Python 2.7 , enum==0.4.6 will no longer work for fresh installation. If someone create virtualenv it will use setuptools==45.0.0 and that does not support  Python2.7 repos properly because with 45.0.0 some of the modules are inbuilt .